### PR TITLE
Fix version matching for gcov 9

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -60,7 +60,7 @@ def stopwatch():
 
 def parseVersionFromLine(version_str):
     """Given a string containing a dotted integer version, parse out integers and return as tuple"""
-    version = re.search(r'(\d+\.\d+\.\d+)[^\.]', version_str)
+    version = re.search(r'(\d+\.\d+\.\d+)', version_str)
 
     if not version:
         return (0,0,0)

--- a/test/version_parse.test.py
+++ b/test/version_parse.test.py
@@ -13,10 +13,18 @@ class TestVersionParse(unittest.TestCase):
     def test_ubuntu_18_04(self):
         version_str = "gcov (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0"
         self.assertEqual(fastcov.parseVersionFromLine(version_str), (7,3,0))
+        
+    def test_ubuntu_test_ppa(self):
+        version_str = "gcov (Ubuntu 9.1.0-2ubuntu2~16.04) 9.1.0"
+        self.assertEqual(fastcov.parseVersionFromLine(version_str), (9,1,0))
 
     def test_experimental(self):
         version_str = "gcov (GCC) 9.0.1 20190401 (experimental)"
         self.assertEqual(fastcov.parseVersionFromLine(version_str), (9,0,1))
+        
+    def test_upstream(self):
+        version_str = "gcov (GCC) 9.1.0"
+        self.assertEqual(fastcov.parseVersionFromLine(version_str), (9,1,0))
 
     def test_no_version(self):
         version_str = "gcov (GCC)"


### PR DESCRIPTION
My gcov returns `gcov (GCC) 9.1.0` for `gcov -v` and for some reason the regex does not match it (python 3.7.3). Ignoring the last character makes it pass.