### PR TITLE
python2 and travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 build/
 dist/
 *.egg-info
+*.gcda
+*.gcno
+test/out/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+before_install:
+  - docker build -t fastcov-test -f travis.Dockerfile .
+
+script:
+  - cd $TRAVIS_BUILD_DIR &&
+    docker run -v"$(pwd):/mnt/workspace" fastcov-test bash -c
+    "cp -r /mnt/workspace /tmp/fastcov-test && cd /tmp/fastcov-test && ./test.sh"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = fastcov
-version = 1.0
+version = 1.1
 description = A massively parallel gcov wrapper for generating intermediate coverage formats fast
 author = Bryan Gillespie
 author-email = rpgillespie6@gmail.com
@@ -18,8 +18,9 @@ platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable
     Topic :: Utilities
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -34,7 +35,7 @@ classifiers =
 [options]
 setup_requires =
 install_requires =
-python_requires = >= 3.5
+python_requires = >= 2.7
 py_modules = fastcov
 
 [options.entry_points]

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# Test fastcov against a basic hello world c app in various python versions
+
+set -e
+set +x
+
+cd test
+mkdir -p out
+gcc-9 hello.c -coverage -o out/hello
+./out/hello
+
+for py in 2 3; do
+    pyversion=$(python$py --version 2>&1)
+    echo
+    echo ">>Testing $pyversion"
+    python$py ../fastcov.py -c $(pwd) --gcov gcov-9 --branch-coverage --lcov -o "$(pwd)/out/py"$py"_result.info"
+    outdir="$(pwd)/out/py"$py"_html"
+    genhtml --branch-coverage -p "$(cd ..; pwd)" -o $outdir "$(pwd)/out/py"$py"_result.info"
+    echo "Results in file://$outdir/index.html for lcov results"
+done

--- a/test/hello.c
+++ b/test/hello.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+static void print_hello(int again) {
+  // Branch coverage, two possible branches
+  printf("Hello%s!\n", again ? " again" : "");
+}
+
+int main(int argc, char **argv) {
+  print_hello(0);
+  print_hello(1);
+  return 0;
+}

--- a/travis.Dockerfile
+++ b/travis.Dockerfile
@@ -1,0 +1,16 @@
+# Ubuntu based image providing gcc-9 for testing
+
+FROM ubuntu:disco
+
+RUN apt-get update && \
+    apt-get install -y \
+    cmake \
+    gcc-9 \
+    lcov \
+    python2 \
+    python3
+
+# Following is required in docker containers when locale is not set, for
+# python sys.stdout.encoding to be not None. Another option is to use
+# (sys.stdout.encoding or "utf-8") in python instead.
+ENV PYTHONIOENCODING utf-8


### PR DESCRIPTION
This is a PR combining two patches:
1. modifications to `fastcov.py` and setup config to support python2.7, and add a tiny test script for python2 and python3
2. adding travis ci infrastructure files to run the test script

The test I added only has a single .gcda file :confused: so it doesn't do any validation of the multiprocessing stuff. I looked at a few example c repos; [curl's](https://github.com/curl/curl/blob/master/scripts/coverage.sh) looked the closest, but when I tested, fastcov skipped the gcda files, not sure what I was doing wrong there.

Feel free to take part or none of these changes, figured I'd share them over here in case they're useful!