### PR TITLE
Add More Branch Filtering

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = fastcov
-version = 1.0
+version = 1.1
 description = A massively parallel gcov wrapper for generating intermediate coverage formats fast
 author = Bryan Gillespie
 author-email = rpgillespie6@gmail.com

--- a/test/utils.test.py
+++ b/test/utils.test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+    Author: Bryan Gillespie
+
+    Make sure fastcov internal utils are working as expected
+"""
+
+import unittest
+import fastcov
+
+class TestUtils(unittest.TestCase):
+
+    def test_tupleToDotted(self):
+        actual_to_expected = {
+            (1,0): "1.0",
+            (0,7,8): "0.7.8",
+            (1,2,3,4,5): "1.2.3.4.5",
+        }
+
+        for actual, expected in actual_to_expected.items():
+            self.assertEqual(fastcov.tupleToDotted(actual), expected)
+
+        with self.assertRaises(TypeError):
+            fastcov.tupleToDotted(123)
+
+    def test_chunk(self):
+        chunk_me = [1,2,3,4,5,6,7,8,9,10]
+        expected = [
+            [1,2,3,4],
+            [5,6,7,8],
+            [9,10],
+        ]
+
+        self.assertEqual(len(list(fastcov.chunks(chunk_me, 4))), len(expected))
+        for i, chunk in enumerate(fastcov.chunks(chunk_me, 4)):
+            self.assertEqual(chunk, expected[i])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/version_parse.test.py
+++ b/test/version_parse.test.py
@@ -13,7 +13,7 @@ class TestVersionParse(unittest.TestCase):
     def test_ubuntu_18_04(self):
         version_str = "gcov (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0"
         self.assertEqual(fastcov.parseVersionFromLine(version_str), (7,3,0))
-        
+
     def test_ubuntu_test_ppa(self):
         version_str = "gcov (Ubuntu 9.1.0-2ubuntu2~16.04) 9.1.0"
         self.assertEqual(fastcov.parseVersionFromLine(version_str), (9,1,0))
@@ -21,7 +21,7 @@ class TestVersionParse(unittest.TestCase):
     def test_experimental(self):
         version_str = "gcov (GCC) 9.0.1 20190401 (experimental)"
         self.assertEqual(fastcov.parseVersionFromLine(version_str), (9,0,1))
-        
+
     def test_upstream(self):
         version_str = "gcov (GCC) 9.1.0"
         self.assertEqual(fastcov.parseVersionFromLine(version_str), (9,1,0))


### PR DESCRIPTION
Description:
- Add new option `--include-br-lines-starting-with` for white listing branch coverage statements
- For example, `--include-br-lines-starting-with if else` would only include branch coverage for statements starting with `if` or `else`
- Standardized logging to always use `.format()`