### PR TITLE
Make filter paths absolute

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -27,7 +27,7 @@ import threading
 import subprocess
 import multiprocessing
 
-FASTCOV_VERSION = (1,3)
+FASTCOV_VERSION = (1,4)
 MINIMUM_PYTHON  = (3,5)
 MINIMUM_GCOV    = (9,0,0)
 
@@ -136,14 +136,14 @@ def processGcov(cwd, gcov, files, gcov_filter_options):
     # Check include filter
     if gcov_filter_options["include"]:
         for ex in gcov_filter_options["include"]:
-            if ex in gcov["file"]:
+            if ex in gcov["file_abs"]:
                 files.append(gcov)
                 break
         return
 
     # Check exclude filter
     for ex in gcov_filter_options["exclude"]:
-        if ex in gcov["file"]:
+        if ex in gcov["file_abs"]:
             return
 
     files.append(gcov)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = fastcov
-version = 1.3
+version = 1.4
 description = A massively parallel gcov wrapper for generating intermediate coverage formats fast
 author = Bryan Gillespie
 author-email = rpgillespie6@gmail.com

--- a/test/functional/run_all.sh
+++ b/test/functional/run_all.sh
@@ -34,23 +34,23 @@ ${TEST_DIR}/fastcov.py --gcov gcov-9 --zerocounters  # Clear previous test cover
 ctest -R ctest_1
 
 # Test (basic report generation - no branches)
-coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude test/ --lcov -o test1.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude cmake_project/test/ --lcov -o test1.actual.info
 cmp test1.actual.info ${TEST_DIR}/expected_results/test1.expected.info
 
-coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude test/ --gcov-raw -o test1.actual.gcov.json
+coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude cmake_project/test/ --gcov-raw -o test1.actual.gcov.json
 ${TEST_DIR}/json_cmp.py test1.actual.gcov.json test1.actual.gcov.json #Just check we can parse it for now... gcov race conditions make it hard to compare against expected
 
-coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude test/ -o test1.actual.fastcov.json
+coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude cmake_project/test/ -o test1.actual.fastcov.json
 ${TEST_DIR}/json_cmp.py test1.actual.fastcov.json ${TEST_DIR}/expected_results/test1.expected.fastcov.json
 
 # Test (basic report info - with branches)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude test/ --lcov -o test2.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude cmake_project/test/ --lcov -o test2.actual.info
 cmp test2.actual.info ${TEST_DIR}/expected_results/test2.expected.info
 
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude test/ --gcov-raw -o test2.actual.gcov.json
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude cmake_project/test/ --gcov-raw -o test2.actual.gcov.json
 ${TEST_DIR}/json_cmp.py test2.actual.gcov.json test2.actual.gcov.json #Just check we can parse it for now... gcov race conditions make it hard to compare against expected
 
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude test/ -o test2.actual.fastcov.json
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude cmake_project/test/ -o test2.actual.fastcov.json
 ${TEST_DIR}/json_cmp.py test2.actual.fastcov.json ${TEST_DIR}/expected_results/test2.expected.fastcov.json
 
 # Test (basic lcov info - with branches; equivalent --include)
@@ -91,11 +91,11 @@ if [ "${ENCODING}" != "../src/latin1_enc.cpp: iso-8859-1" ]; then
 fi
 
 # Test (lcov info - with non-utf8 encoding and fallback)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude test/ --fallback-encodings latin1 --lcov -o test8.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude cmake_project/test/ --fallback-encodings latin1 --lcov -o test8.actual.info
 cmp test8.actual.info ${TEST_DIR}/expected_results/latin1_test.expected.info
 
 # Test (lcov info - with non-utf8 encoding and no fallback)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude test/ --lcov -o test9.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude cmake_project/test/ --lcov -o test9.actual.info
 cmp test9.actual.info ${TEST_DIR}/expected_results/latin1_test.expected.info
 
 # Run ctest_3
@@ -103,15 +103,15 @@ ${TEST_DIR}/fastcov.py --gcov gcov-9 --zerocounters # Clear previous test covera
 ctest -R ctest_3
 
 # Test (lcov info - with inclusive branch filtering)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude /usr/include test/ --include-br-lines-starting-with if else --lcov -o include_branches_sw.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude /usr/include cmake_project/test/ --include-br-lines-starting-with if else --lcov -o include_branches_sw.actual.info
 cmp include_branches_sw.actual.info ${TEST_DIR}/expected_results/include_branches_sw.expected.info
 
 # Test (lcov info - with exclusive branch filtering)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude /usr/include test/ --exclude-br-lines-starting-with for if else --lcov -o exclude_branches_sw.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude /usr/include cmake_project/test/ --exclude-br-lines-starting-with for if else --lcov -o exclude_branches_sw.actual.info
 cmp exclude_branches_sw.actual.info ${TEST_DIR}/expected_results/exclude_branches_sw.expected.info
 
 # Test (lcov info - with smart branch filtering)
-coverage run --append ${TEST_DIR}/fastcov.py --branch-coverage --gcov gcov-9 --exclude /usr/include test/ --lcov -o filter_branches.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --branch-coverage --gcov gcov-9 --exclude /usr/include cmake_project/test/ --lcov -o filter_branches.actual.info
 cmp filter_branches.actual.info ${TEST_DIR}/expected_results/filter_branches.expected.info
 
 # Run ctest_all


### PR DESCRIPTION
Use absolute path when deciding what to filter when using filter flags `--exclude` and `--include`
    
Description:
- Fix #17
- Fix #33

