### PR TITLE
Add Verbose Log Traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here are some common filtering combinations you may find useful:
 ```bash
 $ fastcov.py --exclude /usr/include test/ # Exclude system header files and test files from final report
 $ fastcov.py --include src/ # Only include files with "src/" in its path in the final report
-$ fastcov.py --source-files ../src/source1.cpp ../src/source2.cpp # Only include exactly ../src/source1.cpp and ../src/source2.cpp in the final rpeort
+$ fastcov.py --source-files ../src/source1.cpp ../src/source2.cpp # Only include exactly ../src/source1.cpp and ../src/source2.cpp in the final report
 $ fastcov.py --branch-coverage # Only include most useful branches (discards exceptional branches and initializer list branches)
 $ fastcov.py --exceptional-branch-coverage # Include ALL branches in coverage report
 ```

--- a/example/build.sh
+++ b/example/build.sh
@@ -19,7 +19,8 @@ ninja
 ctest
 
 # Run fastcov with smart branch filtering, as well as system header (/usr/include) and cmake project test file filtering
-${BASE_DIR}/fastcov.py -t ExampleTest --gcov gcov-9 --branch-coverage --exclude /usr/include cmake_project/test/ --lcov -o example.info
+# ${BASE_DIR}/fastcov.py -t ExampleTest --gcov gcov-9 --branch-coverage --include cmake_project/src/ --verbose --lcov -o example.info
+${BASE_DIR}/fastcov.py -t ExampleTest --gcov gcov-9 --branch-coverage --exclude /usr/include cmake_project/test/ --verbose --lcov -o example.info
 
 # Generate report with lcov's genhtml
 genhtml --branch-coverage example.info -o coverage_report

--- a/test/functional/run_all.sh
+++ b/test/functional/run_all.sh
@@ -34,7 +34,7 @@ ${TEST_DIR}/fastcov.py --gcov gcov-9 --zerocounters  # Clear previous test cover
 ctest -R ctest_1
 
 # Test (basic report generation - no branches)
-coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude cmake_project/test/ --lcov -o test1.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --verbose --exclude cmake_project/test/ --lcov -o test1.actual.info
 cmp test1.actual.info ${TEST_DIR}/expected_results/test1.expected.info
 
 coverage run --append ${TEST_DIR}/fastcov.py --gcov gcov-9 --exclude cmake_project/test/ -o test1.actual.fastcov.json
@@ -52,15 +52,15 @@ coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gco
 ${TEST_DIR}/json_cmp.py test2.actual.fastcov.json ${TEST_DIR}/expected_results/test2.expected.fastcov.json
 
 # Test (basic lcov info - with branches; equivalent --include)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --include src/ --lcov -o test3.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --verbose --include src/ --lcov -o test3.actual.info
 cmp test3.actual.info ${TEST_DIR}/expected_results/test2.expected.info
 
 # Test (basic lcov info - with branches; equivalent --exclude-gcda)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --exclude-gcda test1.cpp.gcda --lcov -o test4.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --verbose --exclude-gcda test1.cpp.gcda --lcov -o test4.actual.info
 cmp test4.actual.info ${TEST_DIR}/expected_results/test2.expected.info
 
 # Test (basic lcov info - with branches; equivalent --source-files)
-coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --source-files ../src/source1.cpp ../src/source2.cpp --lcov -o test5.actual.info
+coverage run --append ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov gcov-9 --verbose --source-files ../src/source1.cpp ../src/source2.cpp --lcov -o test5.actual.info
 cmp test5.actual.info ${TEST_DIR}/expected_results/test2.expected.info
 
 # Test (basic lcov info - with branches; gcno untested file coverage)
@@ -146,4 +146,4 @@ cmp multitest.actual.info ${TEST_DIR}/expected_results/multitest.expected.info
 
 # Write out coverage as xml
 coverage xml -o coverage.xml
-# coverage html # Generate HTML report
+coverage html # Generate HTML report


### PR DESCRIPTION
Description:
- Fix #41
- Refactor log traces to use python logging
- Add `--verbose` option which sets logging level to debug
- Add some debug level traces to print internal processing