### PR TITLE
Add SPDX licence identifier & URL. No functional change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.com/RPGillespie6/fastcov.svg?branch=master)](https://travis-ci.com/RPGillespie6/fastcov)
 [![Code Coverage](https://img.shields.io/codecov/c/github/rpgillespie6/fastcov.svg)](https://codecov.io/gh/RPGillespie6/fastcov)
 [![PyPI Version](https://img.shields.io/pypi/v/fastcov.svg)](https://pypi.org/project/fastcov/)
+<!-- # SPDX-License-Identifier: MIT -->
 
 # fastcov
 A parallelized gcov wrapper for generating intermediate coverage formats *fast*

--- a/fastcov.py
+++ b/fastcov.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright 2018-present, Bryan Gillespie
 """
     Author: Bryan Gillespie
+    https://github.com/RPGillespie6/fastcov
 
     A massively parallel gcov wrapper for generating intermediate coverage formats fast
 


### PR DESCRIPTION
If you don't mind would suggest a SPDX license ID. Makes it easier for large projects including this to properly track & attribute. Thanks.
