### PR TITLE
Add --no-exclusion option.

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -655,7 +655,7 @@ def main():
     logging.debug("Final report will contain coverage for the following %d source files:\n    %s", len(fastcov_json["sources"]), "\n    ".join(fastcov_json["sources"]))
 
     # Scan for exclusion markers
-    if not args.no_exclusion:
+    if not args.skip_exclusion_markers:
         scanExclusionMarkers(fastcov_json, args.jobs, args.exclude_branches_sw, args.include_branches_sw, args.minimum_chunk, args.fallback_encodings)
         logging.info("Scanned {} source files for exclusion markers".format(len(fastcov_json["sources"])))
 

--- a/fastcov.py
+++ b/fastcov.py
@@ -545,6 +545,7 @@ def parseArgs():
     parser.add_argument('-B', '--exceptional-branch-coverage', dest='xbranchcoverage', action="store_true", help='Include ALL branches in the coverage report (including potentially noisy exceptional branches).')
     parser.add_argument('-A', '--exclude-br-lines-starting-with', dest='exclude_branches_sw', nargs="+", metavar='', default=[], help='Exclude branches from lines starting with one of the provided strings (i.e. assert, return, etc.)')
     parser.add_argument('-a', '--include-br-lines-starting-with', dest='include_branches_sw', nargs="+", metavar='', default=[], help='Include only branches from lines starting with one of the provided strings (i.e. if, else, while, etc.)')
+    parser.add_argument('-X', '--no-exclusion', dest='no_exclusion', action="store_true", help='Suppress reading sources to find exclusions')
 
     # Capture untested file coverage as well via gcno
     parser.add_argument('-n', '--process-gcno', dest='use_gcno', action="store_true", help='Process both gcno and gcda coverage files. This option is useful for capturing untested files in the coverage report.')
@@ -654,8 +655,9 @@ def main():
     logging.debug("Final report will contain coverage for the following %d source files:\n    %s", len(fastcov_json["sources"]), "\n    ".join(fastcov_json["sources"]))
 
     # Scan for exclusion markers
-    scanExclusionMarkers(fastcov_json, args.jobs, args.exclude_branches_sw, args.include_branches_sw, args.minimum_chunk, args.fallback_encodings)
-    logging.info("Scanned {} source files for exclusion markers".format(len(fastcov_json["sources"])))
+    if not args.no_exclusion:
+        scanExclusionMarkers(fastcov_json, args.jobs, args.exclude_branches_sw, args.include_branches_sw, args.minimum_chunk, args.fallback_encodings)
+        logging.info("Scanned {} source files for exclusion markers".format(len(fastcov_json["sources"])))
 
     # Dump to desired file format
     dumpFile(fastcov_json, args)

--- a/fastcov.py
+++ b/fastcov.py
@@ -545,7 +545,7 @@ def parseArgs():
     parser.add_argument('-B', '--exceptional-branch-coverage', dest='xbranchcoverage', action="store_true", help='Include ALL branches in the coverage report (including potentially noisy exceptional branches).')
     parser.add_argument('-A', '--exclude-br-lines-starting-with', dest='exclude_branches_sw', nargs="+", metavar='', default=[], help='Exclude branches from lines starting with one of the provided strings (i.e. assert, return, etc.)')
     parser.add_argument('-a', '--include-br-lines-starting-with', dest='include_branches_sw', nargs="+", metavar='', default=[], help='Include only branches from lines starting with one of the provided strings (i.e. if, else, while, etc.)')
-    parser.add_argument('-X', '--no-exclusion', dest='no_exclusion', action="store_true", help='Suppress reading sources to find exclusions')
+    parser.add_argument('-X', '--skip-exclusion-markers', dest='skip_exclusion_markers', action="store_true", help='Skip reading source files to search for lcov exclusion markers (such as "LCOV_EXCL_LINE")')
 
     # Capture untested file coverage as well via gcno
     parser.add_argument('-n', '--process-gcno', dest='use_gcno', action="store_true", help='Process both gcno and gcda coverage files. This option is useful for capturing untested files in the coverage report.')


### PR DESCRIPTION
This adds a --no-exclusion option. I was getting (correctly) errors that the referenced sources didn't exist, which is due to how my coverage is collected.  This lets me use fastcov as only a data merging tool, and filter later in another tool, which matches my previous use of lcov.

Thanks for considering.
