### PR TITLE
Add ability to filter coverage during combine operations

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -31,7 +31,7 @@ import threading
 import subprocess
 import multiprocessing
 
-FASTCOV_VERSION = (1,6)
+FASTCOV_VERSION = (1,7)
 MINIMUM_PYTHON  = (3,5)
 MINIMUM_GCOV    = (9,0,0)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = fastcov
-version = 1.6
+version = 1.7
 description = A massively parallel gcov wrapper for generating intermediate coverage formats fast
 author = Bryan Gillespie
 author-email = rpgillespie6@gmail.com

--- a/test/functional/expected_results/basic.fastcov.expected.json
+++ b/test/functional/expected_results/basic.fastcov.expected.json
@@ -1,0 +1,41 @@
+{
+    "sources": {
+        "/mnt/workspace/test/functional/cmake_project/src/source2.cpp": {
+            "": {
+                "functions": {
+                    "_Z3barbii": {
+                        "start_line": 3,
+                        "execution_count": 10
+                    }
+                },
+                "branches": {},
+                "lines": {
+                    "3": 10,
+                    "5": 10,
+                    "6": 10,
+                    "8": 0
+                }
+            }
+        },
+        "/mnt/workspace/test/functional/cmake_project/src/source1.cpp": {
+            "": {
+                "functions": {
+                    "_Z3foob": {
+                        "start_line": 3,
+                        "execution_count": 1
+                    }
+                },
+                "branches": {},
+                "lines": {
+                    "3": 1,
+                    "5": 1,
+                    "7": 1001,
+                    "8": 1000,
+                    "10": 1000,
+                    "11": 0,
+                    "14": 1
+                }
+            }
+        }
+    }
+}

--- a/test/functional/run_all.sh
+++ b/test/functional/run_all.sh
@@ -36,6 +36,9 @@ test `find . -name *.gcda | wc -l` -eq 0
 ${TEST_DIR}/fastcov.py --gcov gcov-9 --zerocounters  # Clear previous test coverage
 ctest -R ctest_1
 
+# Create a fastcov JSON to be filtered later
+coverage run -a ${TEST_DIR}/fastcov.py --gcov gcov-9 --verbose -o basic.fastcov.json
+
 # Test (basic report generation - no branches)
 coverage run -a ${TEST_DIR}/fastcov.py --gcov gcov-9 --verbose --exclude cmake_project/test/ --lcov -o test1.actual.info
 cmp test1.actual.info ${TEST_DIR}/expected_results/test1.expected.info
@@ -79,6 +82,16 @@ if coverage run -a ${TEST_DIR}/fastcov.py --gcov ${TEST_DIR}/fake-gcov.sh ; then
     echo "Expected gcov version check to fail"
     exit 1
 fi
+
+# Combine operation - filtering
+coverage run -a ${TEST_DIR}/fastcov.py -C basic.fastcov.json --exclude cmake_project/test/ -o basic.fastcov.actual.json
+${TEST_DIR}/json_cmp.py basic.fastcov.actual.json ${TEST_DIR}/expected_results/basic.fastcov.expected.json
+
+coverage run -a ${TEST_DIR}/fastcov.py -C basic.fastcov.json --include cmake_project/src/ -o basic.fastcov2.actual.json
+${TEST_DIR}/json_cmp.py basic.fastcov2.actual.json ${TEST_DIR}/expected_results/basic.fastcov.expected.json
+
+coverage run -a ${TEST_DIR}/fastcov.py -C basic.fastcov.json --source-files /mnt/workspace/test/functional/cmake_project/src/source2.cpp /mnt/workspace/test/functional/cmake_project/src/source1.cpp -o basic.fastcov3.actual.json
+${TEST_DIR}/json_cmp.py basic.fastcov3.actual.json ${TEST_DIR}/expected_results/basic.fastcov.expected.json
 
 # Combine operation
 coverage run -a ${TEST_DIR}/fastcov.py -C ${TEST_DIR}/expected_results/test2.expected.info ${TEST_DIR}/expected_results/test1.tn.expected.info --lcov -o combine1.actual.info


### PR DESCRIPTION
Description:
- Fix #48
- Filter options can now be applied during combine operations (`-C`)

