### PR TITLE
ADDED: ability to filter coverage based on unified diff file

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -72,7 +72,6 @@ class DiffParser(object):
             #sources without added lines will be excluded
             if value:
                 newpath = os.path.join(diff_base_dir, key) if diff_base_dir else os.path.abspath(key)
-                newpath = newpath.replace('\\', '/')
                 diff_metadata[newpath] = value
 
     def _parseTargetFile(self, line_with_target_file):

--- a/test/functional/expected_results/diff_filter_data/basic.json
+++ b/test/functional/expected_results/diff_filter_data/basic.json
@@ -1,0 +1,55 @@
+{
+    "sources": {
+        "/mnt/workspace/test/functional/cmake_project/src/source2.cpp": {
+            "": {
+                "functions": {
+                    "_Z3barbii": {
+                        "start_line": 3,
+                        "execution_count": 10
+                    }
+                },
+                "branches": {
+                    "5": [
+                        10,
+                        0
+                    ]
+                },
+                "lines": {
+                    "3": 10,
+                    "5": 10,
+                    "6": 10,
+                    "8": 0
+                }
+            }
+        },
+        "/mnt/workspace/test/functional/cmake_project/src/source1.cpp": {
+            "": {
+                "functions": {
+                    "_Z3foob": {
+                        "start_line": 3,
+                        "execution_count": 1
+                    }
+                },
+                "branches": {
+                    "7": [
+                        1000,
+                        1
+                    ],
+                    "10": [
+                        0,
+                        1000
+                    ]
+                },
+                "lines": {
+                    "3": 1,
+                    "5": 1,
+                    "7": 1001,
+                    "8": 1000,
+                    "10": 1000,
+                    "11": 0,
+                    "14": 1
+                }
+            }
+        }
+    }
+}

--- a/test/functional/expected_results/diff_filter_data/exclude_each_item.diff
+++ b/test/functional/expected_results/diff_filter_data/exclude_each_item.diff
@@ -1,0 +1,16 @@
+diff --git a/test/functional/cmake_project/src/source1.cpp b/test/functional/cmake_project/src/source1.cpp
+index 0c5409a..17f860a 100644
+--- a/test/functional/cmake_project/src/source1.cpp
++++ b/test/functional/cmake_project/src/source1.cpp
+@@ -2,9 +2,9 @@
+ 
+ int foo(bool take_branch)
+ {
+-    int x = 0;
++    int x = 0;//test
+ 
+-    for (int i = 0; i < 1000; i++) {
++    for (int i = 0; i < 1000; i++) {//test
+         x += 2*i;
+ 
+         if (take_branch)

--- a/test/functional/expected_results/diff_filter_data/exclude_each_item.expected.json
+++ b/test/functional/expected_results/diff_filter_data/exclude_each_item.expected.json
@@ -1,0 +1,19 @@
+{
+    "sources": {
+        "/mnt/workspace/test/functional/cmake_project/src/source1.cpp": {
+            "": {
+                "functions": {},
+                "branches": {
+                    "7": [
+                        1000,
+                        1
+                    ]
+                },
+                "lines": {
+                    "5": 1,
+                    "7": 1001
+                }
+            }
+        }
+    }
+}

--- a/test/functional/run_all.sh
+++ b/test/functional/run_all.sh
@@ -198,6 +198,10 @@ cat print_coverage.info.log | grep 'Files Coverage: 66.67%, 2/3'
 cat print_coverage.info.log | grep 'Functions Coverage: 60.00%, 3/5'
 cat print_coverage.info.log | grep 'Lines Coverage: 60.00%, 9/15'
 
+# Test (diff filtering)
+coverage run -a ${TEST_DIR}/fastcov.py -C ${TEST_DIR}/expected_results/diff_filter_data/basic.json --diff-filter ${TEST_DIR}/expected_results/diff_filter_data/exclude_each_item.diff --diff-base-dir /mnt/workspace -o exclude_each_item.actual.json
+${TEST_DIR}/json_cmp.py exclude_each_item.actual.json ${TEST_DIR}/expected_results/diff_filter_data/exclude_each_item.expected.json
+
 # Write out coverage as xml
 coverage combine
 coverage xml -o coverage.xml

--- a/test/unit/diff_tests_data/bad_encoding.diff
+++ b/test/unit/diff_tests_data/bad_encoding.diff
@@ -1,0 +1,19 @@
+diff --git a/test.txt b/test.txt
+index 003b84f..e086bf8 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,12 +1,9 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result¿–
+-
+ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++    assert not result_test
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
++	newLine
+     assert not result

--- a/test/unit/diff_tests_data/basic.json
+++ b/test/unit/diff_tests_data/basic.json
@@ -1,0 +1,55 @@
+{
+    "sources": {
+        "/mnt/workspace/test/functional/cmake_project/src/source2.cpp": {
+            "": {
+                "functions": {
+                    "_Z3barbii": {
+                        "start_line": 3,
+                        "execution_count": 10
+                    }
+                },
+                "branches": {
+                    "5": [
+                        10,
+                        0
+                    ]
+                },
+                "lines": {
+                    "3": 10,
+                    "5": 10,
+                    "6": 10,
+                    "8": 0
+                }
+            }
+        },
+        "/mnt/workspace/test/functional/cmake_project/src/source1.cpp": {
+            "": {
+                "functions": {
+                    "_Z3foob": {
+                        "start_line": 3,
+                        "execution_count": 1
+                    }
+                },
+                "branches": {
+                    "7": [
+                        1000,
+                        1
+                    ],
+                    "10": [
+                        0,
+                        1000
+                    ]
+                },
+                "lines": {
+                    "3": 1,
+                    "5": 1,
+                    "7": 1001,
+                    "8": 1000,
+                    "10": 1000,
+                    "11": 0,
+                    "14": 1
+                }
+            }
+        }
+    }
+}

--- a/test/unit/diff_tests_data/deleted_file.diff
+++ b/test/unit/diff_tests_data/deleted_file.diff
@@ -1,0 +1,7 @@
+diff --git a/test.txt b/test.txt
+deleted file mode 100755
+index 9daeafb..0000000
+--- a/test.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-test

--- a/test/unit/diff_tests_data/exclude_each_item.diff
+++ b/test/unit/diff_tests_data/exclude_each_item.diff
@@ -1,0 +1,16 @@
+diff --git a/test/functional/cmake_project/src/source1.cpp b/test/functional/cmake_project/src/source1.cpp
+index 0c5409a..17f860a 100644
+--- a/test/functional/cmake_project/src/source1.cpp
++++ b/test/functional/cmake_project/src/source1.cpp
+@@ -2,9 +2,9 @@
+ 
+ int foo(bool take_branch)
+ {
+-    int x = 0;
++    int x = 0;//test
+ 
+-    for (int i = 0; i < 1000; i++) {
++    for (int i = 0; i < 1000; i++) {//test
+         x += 2*i;
+ 
+         if (take_branch)

--- a/test/unit/diff_tests_data/exclude_each_item.expected.json
+++ b/test/unit/diff_tests_data/exclude_each_item.expected.json
@@ -1,0 +1,19 @@
+{
+    "sources": {
+        "/mnt/workspace/test/functional/cmake_project/src/source1.cpp": {
+            "": {
+                "functions": {},
+                "branches": {
+                    "7": [
+                        1000,
+                        1
+                    ]
+                },
+                "lines": {
+                    "5": 1,
+                    "7": 1001
+                }
+            }
+        }
+    }
+}

--- a/test/unit/diff_tests_data/exclude_few_lines.diff
+++ b/test/unit/diff_tests_data/exclude_few_lines.diff
@@ -1,0 +1,37 @@
+diff --git a/test/functional/cmake_project/src/source1.cpp b/test/functional/cmake_project/src/source1.cpp
+index 0c5409a..ac53825 100644
+--- a/test/functional/cmake_project/src/source1.cpp
++++ b/test/functional/cmake_project/src/source1.cpp
+@@ -2,13 +2,13 @@
+ 
+ int foo(bool take_branch)
+ {
+-    int x = 0;
++    int x = 0;//test
+ 
+-    for (int i = 0; i < 1000; i++) {
++    for (int i = 0; i < 1000; i++) {//test
+         x += 2*i;
+ 
+         if (take_branch)
+-            x += i;
++            x += i;//test
+     }
+ 
+     return x;
+diff --git a/test/functional/cmake_project/src/source2.cpp b/test/functional/cmake_project/src/source2.cpp
+index 14c9576..d3f3b51 100644
+--- a/test/functional/cmake_project/src/source2.cpp
++++ b/test/functional/cmake_project/src/source2.cpp
+@@ -2,8 +2,8 @@
+ 
+ int bar(bool a, int b, int c)
+ {
+-    if (a)
++    if (a)//test
+         return b + c;
+ 
+-    return b - c;
++    return b - c;//test
+ }
+\ No newline at end of file

--- a/test/unit/diff_tests_data/exclude_few_lines.expected.json
+++ b/test/unit/diff_tests_data/exclude_few_lines.expected.json
@@ -1,0 +1,35 @@
+{
+    "sources": {
+        "/mnt/workspace/test/functional/cmake_project/src/source2.cpp": {
+            "": {
+                "functions": {},
+                "branches": {
+                    "5": [
+                        10,
+                        0
+                    ]
+                },
+                "lines": {
+                    "5": 10,
+                    "8": 0
+                }
+            }
+        },
+        "/mnt/workspace/test/functional/cmake_project/src/source1.cpp": {
+            "": {
+                "functions": {},
+                "branches": {
+                    "7": [
+                        1000,
+                        1
+                    ]
+                },
+                "lines": {
+                    "5": 1,
+                    "7": 1001,
+                    "11": 0
+                }
+            }
+        }
+    }
+}

--- a/test/unit/diff_tests_data/few_files_with_few_added_hunks.diff
+++ b/test/unit/diff_tests_data/few_files_with_few_added_hunks.diff
@@ -1,0 +1,77 @@
+diff --git a/test.txt b/test.txt
+index 003b84f..87f85cc 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,4 +1,14 @@
+
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
++
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+     assert not result
+@@ -10,3 +20,14 @@ def test_DiffParser_parseDiffFile_no_files():
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
+     assert not result
++
++
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
+\ No newline at end of file
+diff --git a/test2.txt b/test2.txt
+index 6971d41..a4e662e 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,6 +7,10 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
++def test_DiffParser_parseDiffFile_no_files():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++    assert not result
++
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
+     assert not result
+diff --git a/test3.txt b/test3.txt
+index 6971d41..55d250a 100644
+--- a/test3.txt
++++ b/test3.txt
+@@ -2,6 +2,13 @@
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+     assert not result
++
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
++def test_DiffParser_parseDiffFile_empty():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++    assert not result
+
+ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+@@ -11,3 +18,8 @@ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
+     assert not result
+
++
++def test_DiffParser_parseDiffFile_deleted_file():
++    result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
++    assert not result
++

--- a/test/unit/diff_tests_data/few_files_with_few_modified_hunks.diff
+++ b/test/unit/diff_tests_data/few_files_with_few_modified_hunks.diff
@@ -1,0 +1,94 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+@@ -22,12 +22,12 @@ def test_DiffParser_parseDiffFile_deleted_file():
+     assert not result
+
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+\ No newline at end of file
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+\ No newline at end of file
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
+diff --git a/test3.txt b/test3.txt
+index 55d250a..81467e8 100644
+--- a/test3.txt
++++ b/test3.txt
+@@ -1,7 +1,7 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+@@ -19,7 +19,7 @@ def test_DiffParser_parseDiffFile_deleted_file():
+     assert not result
+
+
+-def test_DiffParser_parseDiffFile_deleted_file():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_deleted_file():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
++		assert not result
+

--- a/test/unit/diff_tests_data/file_del_mod_add_lines.diff
+++ b/test/unit/diff_tests_data/file_del_mod_add_lines.diff
@@ -1,0 +1,19 @@
+diff --git a/test.txt b/test.txt
+index 003b84f..e086bf8 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,12 +1,9 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-
+ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++    assert not result_test
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')
++	newLine
+     assert not result

--- a/test/unit/diff_tests_data/hunk_longer_than_expected.diff
+++ b/test/unit/diff_tests_data/hunk_longer_than_expected.diff
@@ -1,0 +1,45 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/hunk_longer_than_expected2.diff
+++ b/test/unit/diff_tests_data/hunk_longer_than_expected2.diff
@@ -1,0 +1,45 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/hunk_shorter_than_expected.diff
+++ b/test/unit/diff_tests_data/hunk_shorter_than_expected.diff
@@ -1,0 +1,43 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/hunk_shorter_than_expected2.diff
+++ b/test/unit/diff_tests_data/hunk_shorter_than_expected2.diff
@@ -1,0 +1,43 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/include_1file_no_branches.diff
+++ b/test/unit/diff_tests_data/include_1file_no_branches.diff
@@ -1,0 +1,22 @@
+diff --git a/test/functional/cmake_project/src/source1.cpp b/test/functional/cmake_project/src/source1.cpp
+index 0c5409a..83c48bf 100644
+--- a/test/functional/cmake_project/src/source1.cpp
++++ b/test/functional/cmake_project/src/source1.cpp
+@@ -2,13 +2,13 @@
+ 
+ int foo(bool take_branch)
+ {
+-    int x = 0;
+-
++    int x = 0;//test
++//test
+     for (int i = 0; i < 1000; i++) {
+-        x += 2*i;
++        x += 2*i;//test
+ 
+         if (take_branch)
+-            x += i;
++            x += i;//test
+     }
+ 
+     return x;

--- a/test/unit/diff_tests_data/include_1file_no_branches.expected.json
+++ b/test/unit/diff_tests_data/include_1file_no_branches.expected.json
@@ -1,0 +1,15 @@
+{
+    "sources": {
+        "/mnt/workspace/test/functional/cmake_project/src/source1.cpp": {
+            "": {
+                "functions": {},
+                "branches": {},
+                "lines": {
+                    "5": 1,
+                    "8": 1000,
+                    "11": 0
+                }
+            }
+        }
+    }
+}

--- a/test/unit/diff_tests_data/include_no_lines.diff
+++ b/test/unit/diff_tests_data/include_no_lines.diff
@@ -1,0 +1,13 @@
+diff --git a/test/functional/cmake_project/src/source1.cpp b/test/functional/cmake_project/src/source1.cpp
+index 0c5409a..42bbf00 100644
+--- a/test/functional/cmake_project/src/source1.cpp
++++ b/test/functional/cmake_project/src/source1.cpp
+@@ -3,7 +3,7 @@
+ int foo(bool take_branch)
+ {
+     int x = 0;
+-
++//test
+     for (int i = 0; i < 1000; i++) {
+         x += 2*i;
+ 

--- a/test/unit/diff_tests_data/last_hunk_longer_than_expected.diff
+++ b/test/unit/diff_tests_data/last_hunk_longer_than_expected.diff
@@ -1,0 +1,45 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++		assert not result
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/last_hunk_longer_than_expected2.diff
+++ b/test/unit/diff_tests_data/last_hunk_longer_than_expected2.diff
@@ -1,0 +1,45 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')=
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/last_hunk_shorter_than_expected.diff
+++ b/test/unit/diff_tests_data/last_hunk_shorter_than_expected.diff
@@ -1,0 +1,43 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/last_hunk_shorter_than_expected2.diff
+++ b/test/unit/diff_tests_data/last_hunk_shorter_than_expected2.diff
@@ -1,0 +1,43 @@
+diff --git a/test.txt b/test.txt
+index 87f85cc..ad8c6b9 100755
+--- a/test.txt
++++ b/test.txt
+@@ -1,13 +1,13 @@
+
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
+-def test_DiffParser_parseDiffFile_empty():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+-    assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
++	def test_DiffParser_parseDiffFile_empty():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_empty():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/empty.diff', '/base')
+diff --git a/test2.txt b/test2.txt
+index a4e662e..4b3db32 100644
+--- a/test2.txt
++++ b/test2.txt
+@@ -7,9 +7,9 @@ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+     assert not result
+
+-def test_DiffParser_parseDiffFile_no_files():
+-    result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++	def test_DiffParser_parseDiffFile_no_files():
++		result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
++		assert not result
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/diff_tests_data/no_files.diff
+++ b/test/unit/diff_tests_data/no_files.diff
@@ -1,0 +1,3 @@
+diff --git a/test.txt b/test.txt
+old mode 100644
+new mode 100755

--- a/test/unit/diff_tests_data/renamed_edited.diff
+++ b/test/unit/diff_tests_data/renamed_edited.diff
@@ -1,0 +1,16 @@
+diff --git a/test2.txt b/test5.txt
+similarity index 93%
+rename from test2.txt
+rename to test5.txt
+index 6971d41..3a00f05 100644
+--- a/test2.txt
++++ b/test5.txt
+@@ -5,7 +5,7 @@ def test_DiffParser_parseDiffFile_empty():
+
+ def test_DiffParser_parseDiffFile_no_files():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/no_files.diff', '/base')
+-    assert not result
++    assert not result added line
+
+ def test_DiffParser_parseDiffFile_deleted_file():
+     result = fastcov.DiffParser().parseDiffFile('diff_files/deleted_file.diff', '/base')

--- a/test/unit/test_diff_filter.py
+++ b/test/unit/test_diff_filter.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-    Author: Bryan Gillespie
+    Author: Roman Burtnyk
 
-    Make sure fastcov internal utils are working as expected
+    Make sure fastcov diff filtering are working as expected
 """
 
 import json

--- a/test/unit/test_diff_filter.py
+++ b/test/unit/test_diff_filter.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+    Author: Bryan Gillespie
+
+    Make sure fastcov internal utils are working as expected
+"""
+
+import json
+import fastcov
+
+def test_DiffParser_filterByDiff_empty_file():
+    with open('diff_tests_data/basic.json') as f:
+        fastcov_data = json.load(f)
+    actual = fastcov.DiffParser().filterByDiff('diff_tests_data/no_files.diff', '/mnt/workspace', fastcov_data)
+    assert actual == {'sources': {}}
+
+def test_DiffParser_filterByDiff_exclude_few_lines():
+    with open('diff_tests_data/basic.json') as f:
+        fastcov_data = json.load(f)
+        fastcov.convertKeysToInt(fastcov_data)
+    with open('diff_tests_data/exclude_few_lines.expected.json') as f:
+        expected = json.load(f)
+        fastcov.convertKeysToInt(expected)
+    actual = fastcov.DiffParser().filterByDiff('diff_tests_data/exclude_few_lines.diff', '/mnt/workspace', fastcov_data)
+    assert actual == expected
+
+def test_DiffParser_filterByDiff_include_no_lines():
+    with open('diff_tests_data/basic.json') as f:
+        fastcov_data = json.load(f)
+    actual = fastcov.DiffParser().filterByDiff('diff_tests_data/include_no_lines.diff', '/mnt/workspace', fastcov_data)
+    assert actual == {'sources': {}}
+
+def test_DiffParser_filterByDiff_include_one_file_no_branches():
+    with open('diff_tests_data/basic.json') as f:
+        fastcov_data = json.load(f)
+        fastcov.convertKeysToInt(fastcov_data)
+    with open('diff_tests_data/include_1file_no_branches.expected.json') as f:
+        expected = json.load(f)
+        fastcov.convertKeysToInt(expected)
+    actual = fastcov.DiffParser().filterByDiff('diff_tests_data/include_1file_no_branches.diff', '/mnt/workspace', fastcov_data)
+    assert actual == expected
+
+def test_DiffParser_filterByDiff_exclude_each_item():
+    with open('diff_tests_data/basic.json') as f:
+        fastcov_data = json.load(f)
+        fastcov.convertKeysToInt(fastcov_data)
+    with open('diff_tests_data/exclude_each_item.expected.json') as f:
+        expected = json.load(f)
+        fastcov.convertKeysToInt(expected)
+    actual = fastcov.DiffParser().filterByDiff('diff_tests_data/exclude_each_item.diff', '/mnt/workspace', fastcov_data)
+    assert actual == expected

--- a/test/unit/test_diff_parser.py
+++ b/test/unit/test_diff_parser.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+    Author: Bryan Gillespie
+
+    Make sure fastcov internal utils are working as expected
+"""
+
+import pytest
+import fastcov
+
+
+def test_DiffParser_parseTargetFile_usual():
+    actual = fastcov.DiffParser()._parseTargetFile('+++ file1/tests   \n')
+    assert actual == 'file1/tests'
+    actual = fastcov.DiffParser()._parseTargetFile('+++ test2')
+    assert actual == 'test2'
+
+def test_DiffParser_parseTargetFile_empty():
+    actual = fastcov.DiffParser()._parseTargetFile('+++ ')
+    assert actual == ''
+
+def test_DiffParser_parseTargetFile_with_prefix():
+    actual = fastcov.DiffParser()._parseTargetFile('+++ b/dir2/file\n')
+    assert actual == 'dir2/file'
+    actual = fastcov.DiffParser()._parseTargetFile('+++ b/b/file\n')
+    assert actual == 'b/file'
+    actual = fastcov.DiffParser()._parseTargetFile('+++ bfile/b\n')
+    assert actual == 'bfile/b'
+
+def test_DiffParser_parseTargetFile_with_timestamp():
+    actual = fastcov.DiffParser()._parseTargetFile('+++ base/test_file.txt\t2002-02-21 23:30:39.942229878 -0800')
+    assert actual == 'base/test_file.txt'
+
+def test_DiffParser_parseHunkBoundaries_usual():
+    tstart,tlen, sstart, slen = fastcov.DiffParser()._parseHunkBoundaries('@@ -1,2 +3,4 @@ zero line  \n', 1)
+    assert sstart == 1
+    assert slen == 2
+    assert tstart == 3
+    assert tlen == 4
+
+def test_DiffParser_parseHunkBoundaries_count_missed():
+    tstart,tlen, sstart, slen = fastcov.DiffParser()._parseHunkBoundaries('@@ -11 +13,14 @@ zero line  \n', 1)
+    assert sstart == 11
+    assert slen == 1
+    assert tstart == 13
+    assert tlen == 14
+
+    tstart, tlen, sstart, slen = fastcov.DiffParser()._parseHunkBoundaries('@@ -11 +13 @@ zero line  \n', 1)
+    assert sstart == 11
+    assert slen == 1
+    assert tstart == 13
+    assert tlen == 1
+
+    tstart, tlen, sstart, slen = fastcov.DiffParser()._parseHunkBoundaries('@@ -11,12 +13 @@ zero line  \n', 1)
+    assert sstart == 11
+    assert slen == 12
+    assert tstart == 13
+    assert tlen == 1
+
+def test_DiffParser_parseHunkBoundaries_invalid_hunk():
+    with pytest.raises(fastcov.DiffParseError) as e:
+        fastcov.DiffParser()._parseHunkBoundaries('@@ 1112 @@ zero line  \n', 1)
+
+    with pytest.raises(fastcov.DiffParseError) as e:
+        fastcov.DiffParser()._parseHunkBoundaries('@@ @@ zero line  \n', 1)
+
+
+def test_DiffParser_parseDiffFile_empty():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/empty.diff', '/base')
+    assert not result
+
+def test_DiffParser_parseDiffFile_no_files():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/no_files.diff', '/base')
+    assert not result
+
+def test_DiffParser_parseDiffFile_deleted_file():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/deleted_file.diff', '/base')
+    assert not result
+
+def test_DiffParser_parseDiffFile_file_deleted_added_modifiled():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/file_del_mod_add_lines.diff', '/base')
+    assert result == {'/base/test.txt': {4, 8}}
+
+def test_DiffParser_parseDiffFile_file_deleted_added_check_other_base():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/file_del_mod_add_lines.diff', '/base/base2')
+    assert result == {'/base/base2/test.txt': {4, 8}}
+
+def test_DiffParser_parseDiffFile_file_renamed_and_edited():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/renamed_edited.diff', '/base')
+    assert result == {'/base/test5.txt': {8}}
+
+def test_DiffParser_parseDiffFile_few_files_with_few_added_hunks():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/few_files_with_few_added_hunks.diff', '/base')
+    assert result == {"/base/test.txt":{2,3,4,5,6,7,8,9,10,11,23,24,25,26,27,28,29,30,31,32,33},
+                      "/base/test2.txt":{10,11,12,13},
+                      "/base/test3.txt":{5,6,7,8,9,10,11,21,22,23,24,25}
+                      }
+
+def test_DiffParser_parseDiffFile_few_files_with_few_modified_hunks():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/few_files_with_few_modified_hunks.diff', '/base')
+    assert result == {"/base/test.txt":{2,3,4,5,6,7,8,9,10,25,26,27,28,29,30,31,32,33},
+                      "/base/test2.txt":{10,11,12},
+                      "/base/test3.txt":{2,3,4,22,23,24}
+                      }
+
+def test_DiffParser_parseDiffFile_invalid():
+    with pytest.raises(fastcov.DiffParseError) as e:
+        fastcov.DiffParser()._parseHunkBoundaries('@@ 1112 @@ zero line  \n', 1)
+
+def test_DiffParser_parseDiffFile_hunk_longer_than_expected():
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/hunk_longer_than_expected.diff', '/base')
+
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/hunk_longer_than_expected2.diff', '/base')
+
+def test_DiffParser_parseDiffFile_last_hunk_longer_than_expected():
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/last_hunk_longer_than_expected.diff', '/base')
+
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/last_hunk_longer_than_expected2.diff', '/base')
+
+def test_DiffParser_parseDiffFile_hunk_shorter_than_expected():
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/hunk_shorter_than_expected.diff', '/base')
+
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/hunk_shorter_than_expected2.diff', '/base')
+
+def test_DiffParser_parseDiffFile_last_hunk_shorter_than_expected():
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/last_hunk_shorter_than_expected.diff', '/base')
+
+    with pytest.raises(fastcov.DiffParseError) as e:
+        result = fastcov.DiffParser().parseDiffFile('diff_tests_data/last_hunk_shorter_than_expected2.diff', '/base')
+
+def test_DiffParser_parseDiffFile_bad_encoding():
+    result = fastcov.DiffParser().parseDiffFile('diff_tests_data/bad_encoding.diff', '/base')
+    assert result == {'/base/test.txt': {4, 8}}

--- a/test/unit/test_diff_parser.py
+++ b/test/unit/test_diff_parser.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-    Author: Bryan Gillespie
+    Author: Roman Burtnyk
 
-    Make sure fastcov internal utils are working as expected
+    Make sure fastcov diff parser are working as expected
 """
 
 import pytest


### PR DESCRIPTION
Hi,

In this PR want to propose ability to filter coverage according to unified diff file. 

So simple use case is generating diff for pull request, running fastcov with diff + lcov_to_cobertura for CI coverage based on changes. Or diff for pull request, fastcov with diff + genhtml to get changes coverage report.
Currently see no good way to generate changes html coverage report, because usually that is one html file, which become very big and hard to open using browser.
Also good thing is that fastcov can be used as a intermediate step between lcov+genhtml  or lcov + lcov_to_cobertura if someone need to get changes coverage report even if GCC version < 9. 

Please, let me know if this change is reasonable, so I will add some unittests to check diff parsing and functional to check overall scenario.
