### PR TITLE
Test instance where gcov crashes or is killed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - docker run -v "$TRAVIS_BUILD_DIR":/mnt/workspace -w /mnt/workspace rpgillespie6/fastcov bash -c "cd ./test && ./run_tests.sh"
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -X gcov -X coveragepy -s $TRAVIS_BUILD_DIR # Upload coverage to codecov
+  - bash <(curl -s https://codecov.io/bash) -X coveragepy -s $TRAVIS_BUILD_DIR # Upload coverage to codecov
 
 deploy:
   provider: pypi

--- a/test/functional/bad-gcov.sh
+++ b/test/functional/bad-gcov.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$1" == "-v" ]; then
+  echo "gcov (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0"
+fi
+
+echo "{bad json" # Pretend gcov crashed or was killed

--- a/test/functional/run_all.sh
+++ b/test/functional/run_all.sh
@@ -165,6 +165,11 @@ rc=0
 coverage run -a ${TEST_DIR}/fastcov.py -C ${TEST_DIR}/expected_results/missing_files.json --scan-exclusion-markers -o missing.json || rc=$?
 test $rc -eq 6
 
+# Test gcov getting killed or crashing midway through JSON output
+rc=0
+coverage run -a ${TEST_DIR}/fastcov.py --exceptional-branch-coverage --gcov ${TEST_DIR}/bad-gcov.sh --source-files ../src/source1.cpp --lcov -o multitest.actual.info || rc=$?
+test $rc -eq 7
+
 # Test (running data from other than build directory)
 RUN_DIR=${PWD}
 pushd ${TEST_DIR}


### PR DESCRIPTION
- Fix #59 
- If gcov crashes or is killed, fastcov will hang because it blocks on multiprocessing queues
- This was previously fixed by catching exceptions
- This adds automated testing to this fix