### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 
 language: python
-python: 3.5
+python: 3.6
 
 branches:
   only:


### PR DESCRIPTION
Fixes #71. This is a workaround for https://github.com/travis-ci/dpl/issues/1232.

Travis-CI's deployment scripts assume the latest version of `pip` will work with all Python versions, but `pip` has dropped support for Python 3.5, and Travis-CI hasn't updated their script.