### PR TITLE
Optimize Exclusion Scanning

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -31,7 +31,7 @@ import threading
 import subprocess
 import multiprocessing
 
-FASTCOV_VERSION = (1,11)
+FASTCOV_VERSION = (1,13)
 MINIMUM_PYTHON  = (3,5)
 MINIMUM_GCOV    = (9,0,0)
 
@@ -454,7 +454,7 @@ def exclProcessSource(fastcov_sources, source, exclude_branches_sw, include_bran
                 return False
     
     # If we've made it this far we have to check every line
-    
+
     start_line = 0
     end_line = 0
     # Start enumeration at line 1 because the first line of the file is line 1 not 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = fastcov
-version = 1.11
+version = 1.13
 description = A massively parallel gcov wrapper for generating intermediate coverage formats fast
 author = Bryan Gillespie
 author-email = rpgillespie6@gmail.com


### PR DESCRIPTION
Description:
    - Fix #73
    - Scan file for LCOV_EXCL before processing line by line
    - Shuffle/add conditionals to potentially spin through exclusion scan loop faster
    - Use multiprocessing to scan for exclusion markers instead of multithreading
    - fastcov to 1.13
    - Skipping 1.12 because tag already exists