### PR TITLE
Fix process-gcno/zerocounters behavior

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -31,7 +31,7 @@ import threading
 import subprocess
 import multiprocessing
 
-FASTCOV_VERSION = (1,13)
+FASTCOV_VERSION = (1,14)
 MINIMUM_PYTHON  = (3,5)
 MINIMUM_GCOV    = (9,0,0)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = fastcov
-version = 1.13
+version = 1.14
 description = A massively parallel gcov wrapper for generating intermediate coverage formats fast
 author = Bryan Gillespie
 author-email = rpgillespie6@gmail.com


### PR DESCRIPTION
- Do not remove gcno files when `--zerocounters` is passed with `--process-gcno`
- Also bump fastcov minor version