### PR TITLE
FIXED: do not rewrite previous result for SF 

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -742,13 +742,13 @@ def parseInfo(path):
                 current_test_name = line[3:].strip()
             elif line.startswith("SF:"):
                 current_sf = line[3:].strip()
-                fastcov_json["sources"][current_sf] = {
+                fastcov_json["sources"].setdefault(current_sf, {
                     current_test_name: {
                         "functions": {},
                         "branches": {},
                         "lines": {},
                     }
-                }
+                })
                 current_data = fastcov_json["sources"][current_sf][current_test_name]
             elif line.startswith("FN:"):
                 line_num, function_name = line[3:].strip().split(",")


### PR DESCRIPTION
I have LCOV info file in which some SF(source files) are presented multiple times. This patch fixes issue due to which only last info saved by fastcov for such files.