### PR TITLE
Handle negative line counts

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -642,6 +642,10 @@ def filterExceptionalBranches(branches):
 def distillLine(line_raw, lines, branches, include_exceptional_branches):
     line_number = int(line_raw["line_number"])
     count       = int(line_raw["count"])
+    if count <  0:
+        logging.warning("Ignoring negative count found in %s.", line_raw["function_name"])
+        count = 0
+
     if line_number not in lines:
         lines[line_number] = count
     else:


### PR DESCRIPTION
It is a known issue that GCC's gcov can produce negative counts (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67937), and `lcov` will fix negative counts by zeroing these values (https://github.com/linux-test-project/lcov/blob/d100e6cdd4c67cbe5322fa26b2ee8aa34ea7ebcf/bin/lcov#L1687-L1692) and printing a warning: `lcov: WARNING: negative counts found in tracefile...`

Currently, `fastcov` takes the counts for a given line at face value, and adds them. If one of the counts happens to be a negative number larger than the sum of all other hits, it ends up looking like the line is not covered by tests (false negative) -- and even if it's a small negative number, the hit count will be off.

The proposal here is to simply zero the negative value, effectively ignoring it, but I could also see people who would want this behavior to be configurable. I'm happy to make any adjustments accordingly.