### PR TITLE
Added ability to strip source file paths prior to opening them.

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -269,7 +269,10 @@ def processPrefix(path, prefix, prefix_strip):
             p = p.joinpath(s)
 
     if len(prefix) > 0:
-        p = Path(prefix).joinpath(p)
+        if p.is_absolute():
+            p = Path(prefix).joinpath(p.relative_to('/'))
+        else:
+            p = Path(prefix).joinpath(p)
 
     return str(p)
 

--- a/test/unit/test_gcov_prefix_options.py
+++ b/test/unit/test_gcov_prefix_options.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+    Author: Jean-Philippe Lapointe
+
+    Make sure fastcov's gcov prefix options are processing the file paths as expected
+"""
+
+import pytest
+import fastcov
+
+from dataclasses import dataclass
+import os
+
+@dataclass
+class TestSet:
+    __test__ = False
+    path: str
+    prefix: str
+    prefix_strip: int
+    expected_result: str
+
+
+def test_simpleStripping():
+    testPatterns = [
+        # Making the path relative to the root of the git repo
+        TestSet('/home/user1/work/git/repo/subdir/to/some/file.cpp',    '',                             5, 'subdir/to/some/file.cpp'),
+        # Essentially changing user directory from user1 to user2
+        TestSet('/home/user1/work/git/repo/subdir/to/some/file.cpp',    '/home/user2',                  2, '/home/user2/work/git/repo/subdir/to/some/file.cpp'),
+        # Relative path, shouldn't get modified.
+        TestSet('subdir/to/some/file.cpp',                              '/home/user2',                  2, 'subdir/to/some/file.cpp'),
+        # Current file should exist, it won't get messed with
+        TestSet(os.path.abspath(__file__),                              '/home/user2',                  1, os.path.abspath(__file__)),
+        # Just prefixing an already absolute path
+        TestSet('/usr/include/someUnknownHeaderFile.h',                 '/home/user2/work/git/repo',    0, '/home/user2/work/git/repo/usr/include/someUnknownHeaderFile.h')
+    ]
+
+    for elem in testPatterns:
+        assert(fastcov.processPrefix(elem.path, elem.prefix, elem.prefix_strip) == elem.expected_result)


### PR DESCRIPTION
The goal of this addition is to allow fastcov to analyze notes and coverage files that were generated in a different environment. 

One would use the -sp switch to pass-in the absolute path to the project directory where it was built and the resulting source file path would then be a relative one, making exclusion processing work in cross-profiling environments.