### PR TITLE
Fix error on negative counts with no function_name.

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -254,14 +254,14 @@ def processPrefix(path, prefix, prefix_strip):
     p = Path(path)
     if p.exists() or not p.is_absolute():
         return path
-    
+
     if prefix_strip > 0:
         segments = p.parts
 
         if len(segments) < prefix_strip + 1:
             logging.warning("Couldn't strip %i path levels from %s.", prefix_strip, path)
             return path
-        
+
         segments = segments[prefix_strip+1:]
         p = Path(segments[0])
         segments = segments[1:]
@@ -674,7 +674,10 @@ def distillLine(line_raw, lines, branches, include_exceptional_branches):
     line_number = int(line_raw["line_number"])
     count       = int(line_raw["count"])
     if count <  0:
-        logging.warning("Ignoring negative count found in %s.", line_raw["function_name"])
+        if "function_name" in line_raw:
+            logging.warning("Ignoring negative count found in %s.", line_raw["function_name"])
+        else:
+            logging.warning("Ignoring negative count.")
         count = 0
 
     if line_number not in lines:


### PR DESCRIPTION
This fixes a crash with negative counts.  Also fixes some extraneous trailing spaces.

The backtrace this solved is as follows:

```
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/.../fastcov.py", line 335, in gcovWorker
    distillSource(f, base_report["sources"], args.test_name, args.xbranchcoverage)
  File "/.../fastcov.py", line 714, in distillSource
    distillLine(line, sources[source_name][test_name]["lines"], sources[source_name][test_name]["branches"], include_exceptional_branches)
  File "/.../fastcov.py", line 677, in distillLine
    logging.warning("Ignoring negative count found in %s.", line_raw["function_name"])
KeyError: 'function_name'
```

