### PR TITLE
Quote function_name for c++filt

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -675,7 +675,7 @@ def distillLine(line_raw, lines, branches, include_exceptional_branches):
     count       = int(line_raw["count"])
     if count <  0:
         if "function_name" in line_raw:
-            logging.warning("Ignoring negative count found in %s.", line_raw["function_name"])
+            logging.warning("Ignoring negative count found in '%s'.", line_raw["function_name"])
         else:
             logging.warning("Ignoring negative count.")
         count = 0


### PR DESCRIPTION
This quotes the function name in the one error using function names.  Without this, trying to decode the logfile through c++filt will not decode the symbols due to the period at the end of the error message.
