### PR TITLE
Pretty exit when no files found

### DIFF
--- a/fastcov.py
+++ b/fastcov.py
@@ -56,6 +56,7 @@ EXIT_CODES = {
     "excl_not_found": 6,
     "bad_chunk_file": 7,
     "missing_json_key": 8,
+    "no_coverage_files": 9,
 }
 
 # Disable all logging in case developers are using this as a module
@@ -874,6 +875,10 @@ def getGcovCoverage(args):
 
     # Get list of gcda files to process
     coverage_files = findCoverageFiles(args.directory, args.coverage_files, args.use_gcno)
+    if not coverage_files:
+        logging.error("No coverage files found in directory '%s'", args.directory)
+        setExitCode("no_coverage_files")
+        sys.exit(EXIT_CODE)
 
     # If gcda/gcno filtering is enabled, filter them out now
     if args.excludepre:

--- a/fastcov.py
+++ b/fastcov.py
@@ -875,10 +875,6 @@ def getGcovCoverage(args):
 
     # Get list of gcda files to process
     coverage_files = findCoverageFiles(args.directory, args.coverage_files, args.use_gcno)
-    if not coverage_files:
-        logging.error("No coverage files found in directory '%s'", args.directory)
-        setExitCode("no_coverage_files")
-        sys.exit(EXIT_CODE)
 
     # If gcda/gcno filtering is enabled, filter them out now
     if args.excludepre:
@@ -890,6 +886,11 @@ def getGcovCoverage(args):
         removeFiles(globCoverageFiles(args.directory, GCOV_GCDA_EXT))
         logging.info("Removed {} .gcda files".format(len(coverage_files)))
         sys.exit()
+
+    if not coverage_files:
+        logging.error("No coverage files found in directory '%s'", args.directory)
+        setExitCode("no_coverage_files")
+        sys.exit(EXIT_CODE)
 
     # Fire up one gcov per cpu and start processing gcdas
     gcov_filter_options = getGcovFilterOptions(args)


### PR DESCRIPTION
Just a tiny PR to make the output a tiny bit more explicit and simple when the user gives in an input dir that has no coverage files in it

before: 

```txt
[0.037s] [info]: Found 0 coverage files (.gcda)
[0.003s] [info]: Spawned 0 gcov processes, each processing at most 5 coverage files
Traceback (most recent call last):
  File "/usr/local/bin/fastcov", line 1071, in <module>
    main()
  File "/usr/local/bin/fastcov", line 1045, in main
    fastcov_json = getGcovCoverage(args)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/fastcov", line 891, in getGcovCoverage
    fastcov_json = processGcdas(args, coverage_files, gcov_filter_options)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/fastcov", line 368, in processGcdas
    base_fastcov = fastcov_jsons.pop()
                   ^^^^^^^^^^^^^^^^^^^
IndexError: pop from empty list
```

after: 
```txt
[0.038s] [info]: Found 0 coverage files (.gcda)
[0.000s] [error]: No coverage files found in directory '.'
```
